### PR TITLE
Update to 1.5.1 modules

### DIFF
--- a/.abproject
+++ b/.abproject
@@ -23,6 +23,6 @@
 	],
 	"AndroidHardwareAcceleration": "false",
 	"iOSStatusBarStyle": "Default",
-	"FrameworkVersion": "1.4.3",
+	"FrameworkVersion": "1.5.2",
 	"Framework": "NativeScript"
 }

--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ Next, install the app's iOS and Android runtimes, as well as the app's npm depen
 $ tns install
 ```
 
-Open your app's `platforms/android/build.gradle` file and add the following line of code below the two existing `compile "com.android.support"` lines. (Note, this manual step is going away with the next release of Telerik UI for NativeScript.)
-
-```
-compile "com.android.support:recyclerview-v7:$suppotVer"
-```
-
 From there you can use the `run` command to run Groceries on iOS:
 
 ```
@@ -111,4 +105,4 @@ $ tns test android --emulator
 
 For more information on unit testing NativeScript apps, refer to the [NativeScript docs on the topic](http://docs.nativescript.org/core-concepts/testing).
 
-![](https://ga-beacon.appspot.com/UA-111455-24/nativescript/sample-groceries?pixel) 
+![](https://ga-beacon.appspot.com/UA-111455-24/nativescript/sample-groceries?pixel)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"nativescript-social-share": "^1.1.2",
 		"nativescript-telerik-ui": "file:nativescript-ui-stable-dev.tgz",
 		"nativescript-unit-test-runner": "^0.2.8",
-		"tns-core-modules": "1.5.0"
+		"tns-core-modules": "1.5.1"
 	},
 	"scripts": {
 		"lint:jscs": "jscs app",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"email-validator": "^1.0.3",
 		"nativescript-iqkeyboardmanager": "^1.0.0",
 		"nativescript-social-share": "^1.1.2",
-		"nativescript-telerik-ui": "file:nativescript-ui-stable-dev.tgz",
+		"nativescript-telerik-ui": "0.2.3",
 		"nativescript-unit-test-runner": "^0.2.8",
 		"tns-core-modules": "1.5.1"
 	},


### PR DESCRIPTION
Update app to latest modules and use the newest nativescript-telerik-ui.
Note that the old nativescript-telerik-ui doesn't work at all for Android, whereas this version does. Moreover, it eliminates the manual build step.

On the other hand, it is a trial version.

Ping @tjvantoll  - can you take a look at it