### PR TITLE
Updte travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,14 @@ cache:
         - .nvm
         - $HOME/.gradle/caches/
         - $HOME/.gradle/wrapper/
+        - node_modules
 
 install:
     - nvm install 4
     - npm install -g nativescript --ignore-scripts
+    - npm install
     - tns usage-reporting disable
+    - tns error-reporting disable
     - tns platform add android
 
 before_script:


### PR DESCRIPTION
Get back caching of node_modules dir.
Call `npm install` in project dir in order to make sure all dependencies are installed.
Disable error reporting, so CLI will not try to send information for exceptions if such happens.