### PR TITLE
Remove devDependencies required by android runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,7 @@
 	},
 	"homepage": "https://github.com/nativescript/sample-Groceries/groceries",
 	"devDependencies": {
-		"babel-traverse": "6.8.0",
-		"babel-types": "6.8.1",
-		"babylon": "6.8.0",
 		"chai": "^3.4.1",
-		"filewalker": "0.1.2",
 		"jscs": "^2.10.1",
 		"jshint": "^2.8.0",
 		"karma": "^0.13.15",
@@ -28,7 +24,6 @@
 		"karma-mocha": "^0.2.1",
 		"karma-mocha-reporter": "^1.1.5",
 		"karma-nativescript-launcher": "^0.3.1",
-		"lazy": "1.0.11",
 		"mocha": "^2.3.4"
 	},
 	"nativescript": {


### PR DESCRIPTION
Avoid the npm errors from double installation of these dependencies. 
They install on adding android platform.