### PR TITLE
Fix for this inside onQueryEvent callaback

### DIFF
--- a/app/shared/grocery/grocery-list.service.ts
+++ b/app/shared/grocery/grocery-list.service.ts
@@ -64,7 +64,7 @@ export class GroceryListService {
   
   onChildEvent(result:any){
     return firebase.query(
-          this.onQueryEvent,
+          this.onQueryEvent.bind(this),
           "/Groceries",
           {
             orderBy: {


### PR DESCRIPTION
The `onQueryEvent` gets called without `this` context by firebase
cc @jlooper 