### PR TITLE
Fix typo

### DIFF
--- a/app/shared/view-models/user-view-model.js
+++ b/app/shared/view-models/user-view-model.js
@@ -27,7 +27,7 @@ function User(info) {
 
     viewModel.login = function() {
         return firebase.login({
-            type: firebase.loginType.PASSWORD,
+            type: firebase.LoginType.PASSWORD,
             email: viewModel.get("email"),
             password: viewModel.get("password")
           }).then(


### PR DESCRIPTION
It says `type: firebase.loginType.PASSWORD`, but should be `type: firebase.LoginType.PASSWORD` with uppercase "L". This had caused the app to crash for me.