### PR TITLE
Play nice with others using the ios appdelegate

### DIFF
--- a/app/shared/status-bar-util.ts
+++ b/app/shared/status-bar-util.ts
@@ -3,27 +3,15 @@ import * as platform from "platform";
 import * as utils from "utils/utils";
 
 declare var android: any;
-declare var UIResponder: any;
 declare var UIStatusBarStyle: any;
 declare var UIApplication: any;
-declare var UIApplicationDelegate: any;
 
 export function setStatusBarColors() {
   // Make the iOS status bar transparent with white text.
-  // See https://github.com/burkeholland/nativescript-statusbar/issues/2
-  // for details on the technique used.
   if (application.ios) {
-    const AppDelegate = UIResponder.extend({
-      applicationDidFinishLaunchingWithOptions: function() {
-        // Allow for XCode 8 API changes
-        utils.ios.getter(UIApplication, UIApplication.sharedApplication).statusBarStyle = UIStatusBarStyle.LightContent;
-        return true;
-      }
-    }, {
-        name: "AppDelegate",
-        protocols: [UIApplicationDelegate]
-      });
-    application.ios.delegate = AppDelegate;
+    application.on("launch", () => {
+      utils.ios.getter(UIApplication, UIApplication.sharedApplication).statusBarStyle = UIStatusBarStyle.LightContent;
+    });
   }
 
   // Make the Android status bar transparent.


### PR DESCRIPTION
Hi,

I was using this *very nice* sample as a base for an app and wanted to add the [3D Touch plugin](https://github.com/EddyVerbruggen/nativescript-3dtouch) to add home shortcut icons.

The idea of those shortcut icons is you can redirect to different pages in your app according to the shortcut triggered.

To pull that off the dev needs to pass in a callback function, but this callback was never fired because it needs to be triggered by [a function on the iOS appdelegate](https://github.com/EddyVerbruggen/nativescript-3dtouch/blob/master/3dtouch.ios.ts#L20-L34) which turned out to be overridden by code in the statusbar util in this repo.

Since this sample is rather popular (and rightfully so) I'd like it to play nice with other code relying on adding handlers to the appdelegate, so I propose this change. It seems to work equally well, without touching the appdelegate at all.