### PR TITLE
Changes required to make release the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Groceries [![Build Status](https://travis-ci.org/NativeScript/sample-Groceries.svg?branch=master)](https://travis-ci.org/NativeScript/sample-Groceries)
+# Groceries [![Build Status](https://travis-ci.org/NativeScript/sample-Groceries.svg?branch=release)](https://travis-ci.org/NativeScript/sample-Groceries)
 
 Groceries is a NativeScript-built iOS and Android app for managing grocery lists. You can learn how to build a version of this app from scratch using either our [JavaScript getting started guide](http://docs.nativescript.org/tutorial/chapter-0), or our [TypeScript and Angular getting started guide](http://docs.nativescript.org/angular/tutorial/ng-chapter-0).
 
@@ -17,7 +17,7 @@ Groceries is a NativeScript-built iOS and Android app for managing grocery lists
 
 This repository contains a number of branches:
 
-* The [**master** branch](https://github.com/NativeScript/sample-Groceries/) shows how to build a robust, real-world app using NativeScript. The branch is built with TypeScript and Angular.
+* The [**release** branch](https://github.com/NativeScript/sample-Groceries/) shows how to build a robust, real-world app using NativeScript. The branch is built with TypeScript and Angular.
 
 ---
 
@@ -88,7 +88,7 @@ For more information on unit testing NativeScript apps, refer to the [NativeScri
 
 <h3 id="travis">Travis CI</h3>
 
-Groceries uses [Travis CI](https://travis-ci.org/) to verify all tests pass on each commit. Refer to the [`.travis.yml` configuration file](https://github.com/NativeScript/sample-Groceries/blob/master/.travis.yml) for details.
+Groceries uses [Travis CI](https://travis-ci.org/) to verify all tests pass on each commit. Refer to the [`.travis.yml` configuration file](https://github.com/NativeScript/sample-Groceries/blob/release/.travis.yml) for details.
 
 <h3 id="telerik-platform">Telerik Platform</h3>
 


### PR DESCRIPTION
Some minor changes in the Readme.md in order to make `release` the default branch of the repo.
cc @tjvantoll 