### PR TITLE
fix:  unpin nativescript-angular version to ~1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser-dynamic": "~4.0.0",
     "@angular/router": "~4.0.0",
     "email-validator": "1.0.4",
-    "nativescript-angular": "1.5.0",
+    "nativescript-angular": "~1.5.1",
     "nativescript-iqkeyboardmanager": "1.0.1",
     "nativescript-social-share": "~1.3.2",
     "nativescript-unit-test-runner": "^0.3.3",


### PR DESCRIPTION
This will prevent angular packages from being installed twice - under `node_modules/` and `node_modules/nativescript-angular` .

fixes #234, fixes #236