### PR TITLE
fix: use fixed values for connectivityType

### DIFF
--- a/app/login/login.component.ts
+++ b/app/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 import { Router } from "@angular/router";
 import { Color } from "color";
-import { connectionType, getConnectionType } from "connectivity";
+import { getConnectionType } from "connectivity";
 import { Animation } from "ui/animation";
 import { View } from "ui/core/view";
 import { prompt } from "ui/dialogs";
@@ -58,7 +58,7 @@ export class LoginComponent implements OnInit {
   }
 
   login() {
-    if (getConnectionType() === connectionType.none) {
+    if (getConnectionType() === 0) {
       alert("Groceries requires an internet connection to log in.");
       return;
     }
@@ -77,7 +77,7 @@ export class LoginComponent implements OnInit {
   }
 
   signUp() {
-    if (getConnectionType() === connectionType.none) {
+    if (getConnectionType() === 0) {
       alert("Groceries requires an internet connection to register.");
       return;
     }


### PR DESCRIPTION
Workaround a bug with webpacking that doesn't inline `const enum`
values. Should be reverted after the following fix is merged in modules: https://github.com/NativeScript/NativeScript/pull/4038