### PR TITLE
refactor: stop importing from rxjs/Rx

### DIFF
--- a/app/groceries/shared/grocery.service.ts
+++ b/app/groceries/shared/grocery.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NgZone } from "@angular/core";
 import { Http, Headers, Response, ResponseOptions } from "@angular/http";
-import { Observable, BehaviorSubject } from "rxjs/Rx";
+import { Observable } from "rxjs/Observable";
+import { BehaviorSubject } from "rxjs/BehaviorSubject";
 import "rxjs/add/operator/map";
 
 import { BackendService } from "../../shared";

--- a/app/shared/login.service.ts
+++ b/app/shared/login.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { Http, Headers, Response } from "@angular/http";
-import { Observable } from "rxjs/Rx";
+import { Observable } from "rxjs/Observable";
 import "rxjs/add/operator/do";
 import "rxjs/add/operator/map";
 import "rxjs/add/observable/throw";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const nsWebpack = require("nativescript-dev-webpack");
 const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 const { AotPlugin } = require("@ngtools/webpack");
 
@@ -138,6 +139,14 @@ function getRules() {
 
 function getPlugins(platform, env) {
     let plugins = [
+        new BundleAnalyzerPlugin({
+            analyzerMode: "static",
+            openAnalyzer: false,
+            generateStatsFile: true,
+            reportFilename: join(__dirname, "report", `${platform}-report.html`),
+            statsFilename: join(__dirname, "report", `${platform}-stats.json`),
+        }),
+
         new ExtractTextPlugin(mainSheet),
 
         // Vendor libs go to the vendor.js chunk


### PR DESCRIPTION
Instead import only what's needed. Importing from rxjs/Rx breaks
tree-shaking and causes the whole rxjs library to be included in the
bundle.

Bundle.js size [before](https://user-images.githubusercontent.com/7893485/27331210-35e02b4c-55c5-11e7-9afa-c96548fa796d.png) is 670KB.
Bundle.js size [after](https://user-images.githubusercontent.com/7893485/27331212-39a3adda-55c5-11e7-970e-ad368e51acb7.png) is 150KB.

This affects the startup time a little (~250ms for Nexus 5 - API lvl21). The above metrics are for webpack+uglify+snapshot:
Before:
![before](https://user-images.githubusercontent.com/7893485/27331287-81d48250-55c5-11e7-9127-27f81dc06dab.png)
After:
![after](https://user-images.githubusercontent.com/7893485/27331293-832db752-55c5-11e7-9fed-d50e1fa91d6d.png)
