### PR TITLE
Fix duplicate items being added when list is reloaded

### DIFF
--- a/app/groceries/shared/grocery.service.ts
+++ b/app/groceries/shared/grocery.service.ts
@@ -24,6 +24,7 @@ export class GroceryService {
     })
     .map(res => res.json())
     .map(data => {
+      this.allItems = [];
       data.Result.forEach((grocery) => {
         this.allItems.push(
           new Grocery(


### PR DESCRIPTION
Set grocery items array as empty before we push items to the existing list. This fixes issue #277