### PR TITLE
refactor: replace NativeScriptModule with NativeScriptCommonModule

### DIFF
--- a/app/groceries/groceries.module.ts
+++ b/app/groceries/groceries.module.ts
@@ -1,4 +1,4 @@
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { groceriesRouting } from "./groceries.routing";
@@ -8,9 +8,9 @@ import { ItemStatusPipe } from "./grocery-list/item-status.pipe";
 
 @NgModule({
   imports: [
-    NativeScriptModule,
     NativeScriptFormsModule,
-    groceriesRouting
+    NativeScriptCommonModule,
+    groceriesRouting,
   ],
   declarations: [
     GroceriesComponent,

--- a/app/login/login.module.ts
+++ b/app/login/login.module.ts
@@ -1,4 +1,4 @@
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 
@@ -7,9 +7,9 @@ import { LoginComponent } from "./login.component";
 
 @NgModule({
   imports: [
-    NativeScriptModule,
     NativeScriptFormsModule,
-    loginRouting
+    NativeScriptCommonModule,
+    loginRouting,
   ],
   declarations: [
     LoginComponent


### PR DESCRIPTION
NativeScriptModule should be imported only in the root NgModule. For all
other feature modules, NativeScriptCommonModule should be used instead.
Check out https://github.com/NativeScript/nativescript-angular/pull/1196.