### PR TITLE
fix: Crash due to writing to statusBarStyle

### DIFF
--- a/app/shared/status-bar-util.ts
+++ b/app/shared/status-bar-util.ts
@@ -7,13 +7,6 @@ declare var UIStatusBarStyle: any;
 declare var UIApplication: any;
 
 export function setStatusBarColors() {
-  // Make the iOS status bar transparent with white text.
-  if (application.ios) {
-    application.on("launch", () => {
-      utils.ios.getter(UIApplication, UIApplication.sharedApplication).statusBarStyle = UIStatusBarStyle.LightContent;
-    });
-  }
-
   // Make the Android status bar transparent.
   // See http://bradmartin.net/2016/03/10/fullscreen-and-navigation-bar-color-in-a-nativescript-android-app/
   // for details on the technique used.


### PR DESCRIPTION
The latest iOS Runtime exposes `UIApplication`'s `statusBarStyle`
property as read-only because write access to it has been deprecated
since iOS 9.0. See https://developer.apple.com/documentation/uikit/uiapplication/1622988-statusbarstyle?language=objc

The status bar's style is automatically adjusted and this code is not needed. 

The new behavior in iOS is introduced with https://github.com/NativeScript/ios-runtime/pull/1100